### PR TITLE
Added nodemon as a dev dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,5 +32,8 @@
     "koa-logger": "^3.1.0",
     "koa-respond": "^1.0.1",
     "koa-router": "^7.4.0"
+  },
+  "devDependencies": {
+    "nodemon": "^1.17.1"
   }
 }


### PR DESCRIPTION
The current koalerplate assumes nodemon as a global dependency.

This change simply adds nodemon as a dev dependency so this works out of the box.